### PR TITLE
feat: add drag-and-drop sorting to actions and conditions in modal

### DIFF
--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/TabList.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/TabList.vue
@@ -4,6 +4,7 @@ import { ref, useTemplateRef, watch } from "vue";
 import { useSortableAndAutoAnimate } from "@/composables/useSortableAndAutoAnimate";
 
 interface Item {
+  key: string;
   title: string;
   description: string;
   action: () => void;
@@ -25,13 +26,13 @@ const savedOrder = useStorage<string[]>(orderStorageKey, []);
 const list = ref<Item[]>([]);
 
 function initList() {
-  const itemsMap = new Map(props.items.map(item => [item.title, item]));
+  const itemsMap = new Map(props.items.map(item => [item.key, item]));
   const newList: Item[] = [];
 
-  for (const title of savedOrder.value) {
-    if (itemsMap.has(title)) {
-      newList.push(itemsMap.get(title)!);
-      itemsMap.delete(title);
+  for (const key of savedOrder.value) {
+    if (itemsMap.has(key)) {
+      newList.push(itemsMap.get(key)!);
+      itemsMap.delete(key);
     }
   }
 
@@ -44,9 +45,12 @@ function initList() {
 
 initList();
 
-watch(list, (newList) => {
-  savedOrder.value = newList.map(item => item.title);
-}, { deep: true });
+watch(
+  () => list.value.map(item => item.key),
+  (keys) => {
+    savedOrder.value = keys;
+  },
+);
 
 const listContainer = useTemplateRef<HTMLElement>("listContainer");
 
@@ -65,7 +69,7 @@ useSortableAndAutoAnimate({
   >
     <div
       v-for="item in list"
-      :key="item.title"
+      :key="item.key"
       class="
         group flex w-full items-center rounded-md border bg-background text-left
         text-sm transition-colors

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/TabList.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/TabList.vue
@@ -12,7 +12,7 @@ interface Item {
 }
 
 const props = defineProps<{
-  tabValue: string;
+  tabValue: "actions" | "conditions";
   items: Item[];
 }>();
 
@@ -20,16 +20,18 @@ const emit = defineEmits<{
   (e: "close"): void;
 }>();
 
-const orderStorageKey = `headerly-add-mod-modal-${props.tabValue}-order`;
-const savedOrder = useStorage<string[]>(orderStorageKey, []);
+const allOrders = useStorage<{
+  [key in typeof props.tabValue]?: string[];
+}>("headerly-add-mod-modal-order", {});
 
 const list = ref<Item[]>([]);
 
 function initList() {
+  const savedOrder = allOrders.value[props.tabValue] ?? [];
   const itemsMap = new Map(props.items.map(item => [item.key, item]));
   const newList: Item[] = [];
 
-  for (const key of savedOrder.value) {
+  for (const key of savedOrder) {
     if (itemsMap.has(key)) {
       newList.push(itemsMap.get(key)!);
       itemsMap.delete(key);
@@ -48,7 +50,7 @@ initList();
 watch(
   () => list.value.map(item => item.key),
   (keys) => {
-    savedOrder.value = keys;
+    allOrders.value = { ...allOrders.value, [props.tabValue]: keys };
   },
 );
 
@@ -71,24 +73,14 @@ useSortableAndAutoAnimate({
       v-for="item in list"
       :key="item.key"
       class="
-        group flex w-full items-center rounded-md border bg-background text-left
-        text-sm transition-colors
+        group flex w-full items-center rounded-md border bg-background px-2
+        text-left text-sm transition-colors
         hover:bg-accent
+        [[data-sorting]_&:not(.sortable-chosen)]:bg-background!
       "
       :class="{ 'opacity-50': item.disabled }"
     >
       <div
-        data-sort-handle
-        class="
-          flex cursor-grab items-center justify-center pl-2
-          text-muted-foreground opacity-0 transition-opacity
-          group-hover:opacity-100
-          hover:text-foreground
-        "
-      >
-        <i class="i-lucide-grip-vertical size-4" />
-      </div>
-      <button
         class="flex flex-1 flex-col items-start p-3 pl-2"
         :disabled="item.disabled"
         :class="{ 'cursor-not-allowed': item.disabled }"
@@ -103,7 +95,20 @@ useSortableAndAutoAnimate({
         <div class="text-left text-xs text-muted-foreground">
           {{ item.description }}
         </div>
-      </button>
+      </div>
+      <div
+        data-sort-handle
+        class="
+          flex cursor-grab items-center justify-center pl-2
+          text-muted-foreground opacity-0 transition-opacity
+          group-hover:opacity-100
+          group-[.sortable-chosen]:opacity-100
+          hover:text-foreground
+          [[data-sorting]_.group:not(.sortable-chosen)_&]:opacity-0!
+        "
+      >
+        <i class="i-lucide-grip-vertical size-4" />
+      </div>
     </div>
   </div>
 </template>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/TabList.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/TabList.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { useStorage } from "@vueuse/core";
+import { ref, useTemplateRef, watch } from "vue";
+import { useSortableAndAutoAnimate } from "@/composables/useSortableAndAutoAnimate";
+
+interface Item {
+  title: string;
+  description: string;
+  action: () => void;
+  disabled?: boolean;
+}
+
+const props = defineProps<{
+  tabValue: string;
+  items: Item[];
+}>();
+
+const emit = defineEmits<{
+  (e: "close"): void;
+}>();
+
+const orderStorageKey = `headerly-add-mod-modal-${props.tabValue}-order`;
+const savedOrder = useStorage<string[]>(orderStorageKey, []);
+
+const list = ref<Item[]>([]);
+
+function initList() {
+  const itemsMap = new Map(props.items.map(item => [item.title, item]));
+  const newList: Item[] = [];
+
+  for (const title of savedOrder.value) {
+    if (itemsMap.has(title)) {
+      newList.push(itemsMap.get(title)!);
+      itemsMap.delete(title);
+    }
+  }
+
+  for (const item of itemsMap.values()) {
+    newList.push(item);
+  }
+
+  list.value = newList;
+}
+
+initList();
+
+watch(list, (newList) => {
+  savedOrder.value = newList.map(item => item.title);
+}, { deep: true });
+
+const listContainer = useTemplateRef<HTMLElement>("listContainer");
+
+useSortableAndAutoAnimate({
+  listContainer,
+  list: list.value,
+  handle: "[data-sort-handle]",
+});
+</script>
+
+<template>
+  <div
+    ref="listContainer" class="
+      mt-2 flex max-h-[60vh] flex-col gap-1 overflow-y-auto
+    "
+  >
+    <div
+      v-for="item in list"
+      :key="item.title"
+      class="
+        group flex w-full items-center rounded-md border bg-background text-left
+        text-sm transition-colors
+        hover:bg-accent
+      "
+      :class="{ 'opacity-50': item.disabled }"
+    >
+      <div
+        data-sort-handle
+        class="
+          flex cursor-grab items-center justify-center pl-2
+          text-muted-foreground opacity-0 transition-opacity
+          group-hover:opacity-100
+          hover:text-foreground
+        "
+      >
+        <i class="i-lucide-grip-vertical size-4" />
+      </div>
+      <button
+        class="flex flex-1 flex-col items-start p-3 pl-2"
+        :disabled="item.disabled"
+        :class="{ 'cursor-not-allowed': item.disabled }"
+        @click="() => {
+          item.action();
+          emit('close');
+        }"
+      >
+        <div class="font-semibold">
+          {{ item.title }}
+        </div>
+        <div class="text-left text-xs text-muted-foreground">
+          {{ item.description }}
+        </div>
+      </button>
+    </div>
+  </div>
+</template>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/index.vue
@@ -22,6 +22,7 @@ import {
 import { useEventBus } from "@vueuse/core";
 import { ref } from "vue";
 import { openAddModModalKey } from "./open";
+import TabList from "./TabList.vue";
 import { tabs } from "./tabs";
 
 const { defaultTab, class: className } = defineProps<{
@@ -80,30 +81,11 @@ bus.on(({ target }) => {
           </TabsTrigger>
         </TabsList>
         <TabsContent v-for="tab in tabs" :key="tab.value" :value="tab.value">
-          <div class="mt-2 flex max-h-[60vh] flex-col gap-1 overflow-y-auto">
-            <button
-              v-for="{ title, description, action, disabled } in tab.items"
-              :key="title"
-              :disabled
-              class="
-                flex w-full flex-col items-start rounded-md border p-3 text-left
-                text-sm transition-colors
-                hover:bg-accent
-                disabled:pointer-events-none disabled:opacity-50
-              "
-              @click="() => {
-                action()
-                isOpen = false
-              }"
-            >
-              <div class="font-semibold">
-                {{ title }}
-              </div>
-              <div class="text-xs text-muted-foreground">
-                {{ description }}
-              </div>
-            </button>
-          </div>
+          <TabList
+            :tab-value="tab.value"
+            :items="tab.items"
+            @close="isOpen = false"
+          />
         </TabsContent>
       </Tabs>
     </DialogContent>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/index.vue
@@ -76,7 +76,6 @@ bus.on(({ target }) => {
       <Tabs v-model="currentTab" class="w-full">
         <TabsList class="grid w-full grid-cols-2">
           <TabsTrigger v-for="tab in tabs" :key="tab.value" :value="tab.value">
-            <i :class="tab.icon" class="me-2 size-4" />
             {{ tab.label }}
           </TabsTrigger>
         </TabsList>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/tabs.ts
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/tabs.ts
@@ -4,7 +4,6 @@ import { useProfilesStore } from "@/entrypoints/popup/stores/useProfilesStore";
 interface Tab {
   label: string;
   value: "actions" | "conditions";
-  icon: string;
   items: {
     key: string;
     title: string;
@@ -34,7 +33,6 @@ export const tabs: Tab[] = [
   {
     label: "Actions",
     value: "actions",
-    icon: "i-lucide-cross",
     items: [
       {
         key: "modify-request-header",
@@ -69,7 +67,6 @@ export const tabs: Tab[] = [
   {
     label: "Conditions",
     value: "conditions",
-    icon: "i-lucide-list-filter-plus",
     items: [
       {
         key: "url-filter",

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/tabs.ts
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/components/AddModModal/tabs.ts
@@ -6,6 +6,7 @@ interface Tab {
   value: "actions" | "conditions";
   icon: string;
   items: {
+    key: string;
     title: string;
     description: string;
     action: () => void;
@@ -36,16 +37,19 @@ export const tabs: Tab[] = [
     icon: "i-lucide-cross",
     items: [
       {
+        key: "modify-request-header",
         title: "Modify HTTP Request Header",
         description: "Set, remove, or append HTTP request headers.",
         action: () => profilesStore.addModGroup("request", "checkbox"),
       },
       {
+        key: "modify-response-header",
         title: "Modify HTTP Response Header",
         description: "Set, remove, or append HTTP response headers.",
         action: () => profilesStore.addModGroup("response", "checkbox"),
       },
       {
+        key: "cookie-sync-request-header",
         title: "Cookie Sync to Request Header",
         description: "Sync cookies for a specific website to the request header (New permissions need to be granted).",
         action: async () => {
@@ -68,6 +72,7 @@ export const tabs: Tab[] = [
     icon: "i-lucide-list-filter-plus",
     items: [
       {
+        key: "url-filter",
         title: "URL Filter",
         description: "The rule will only match network requests whose URL contains any of the specified substrings. If the list is omitted, the rule is applied to requests with all URLs. An empty list is not allowed. Only one of urlFilter or regexFilter can be specified.",
         action: async () => {
@@ -88,6 +93,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "regex-filter",
         title: "Regex Filter",
         description: "The rule will only match network requests whose URL contains any of the specified substrings. If the list is omitted, the rule is applied to requests with all URLs. An empty list is not allowed. Only one of urlFilter or regexFilter can be specified.",
         action: () => {
@@ -107,6 +113,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "request-domains",
         title: "Request Domains",
         description: "The rule will only match network requests when the domain matches one from the list of requestDomains. If the list is omitted, the rule is applied to requests from all domains. An empty list is not allowed.",
         action: async () => {
@@ -129,6 +136,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "excluded-request-domains",
         title: "Excluded Request Domains",
         description: "The rule will not match network requests when the domains matches one from the list of excludedRequestDomains. If the list is empty or omitted, no domains are excluded. This takes precedence over requestDomains.",
         action: async () => {
@@ -161,6 +169,7 @@ export const tabs: Tab[] = [
       //   action: () => {},
       // },
       {
+        key: "domain-type",
         title: "Domain Type",
         description: "Specifies whether the network request is first-party or third-party to the domain from which it originated.",
         action: () => {
@@ -174,11 +183,13 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "excluded-domain-type",
         title: "Excluded Domain Type",
         description: "Excludes requests based on whether the network request is first-party or third-party to the domain from which it originated. If omitted, all requests are accepted.",
         action: () => {},
       },
       {
+        key: "initiator-domains",
         title: "Initiator Domains",
         description: "The rule will only match network requests originating from the list of initiator domains. If the list is omitted, the rule is applied to requests from all domains. An empty list is not allowed.",
         action: async () => {
@@ -201,6 +212,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "excluded-initiator-domains",
         title: "Excluded Initiator Domains",
         description: "The rule will not match network requests originating from the list of excluded initiator domains. If the list is empty or omitted, no domains are excluded. This takes precedence over initiator domains.",
         action: async () => {
@@ -223,6 +235,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "request-methods",
         title: "Request Methods",
         description: "List of HTTP request methods which the rule can match. An empty list is not allowed. Note: Specifying requestMethods will also exclude non-HTTP(s) requests.",
         action: () => {
@@ -240,6 +253,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "excluded-request-methods",
         title: "Excluded Request Methods",
         description: "List of request methods which the rule won't match. Only one of requestMethods and excludedRequestMethods should be specified. If neither is specified, all request methods are matched.",
         action: () => {
@@ -257,6 +271,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "resource-types",
         title: "Resource Types",
         description: "List of resource types which the rule can match. An empty list is not allowed.",
         action: () => {
@@ -274,6 +289,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "excluded-resource-types",
         title: "Excluded Resource Types",
         description: "List of resource types which the rule won't match. Only one of resourceTypes and excludedResourceTypes should be specified. If neither is specified, all resource types except main_frame are blocked.",
         action: () => {
@@ -291,6 +307,7 @@ export const tabs: Tab[] = [
         },
       },
       {
+        key: "url-regex-filter-case-sensitive",
         title: "Url & Regex Filter Case Sensitive",
         description: "Specifies whether the URL filter is case sensitive.",
         action: () => {


### PR DESCRIPTION
## Motivation and Context
The `AddModModal` allows users to add actions and conditions to their network rule profiles. To improve the user experience, users should be able to organize these lists of items by dragging and dropping them into their preferred order.

## Description
This PR implements drag-and-drop sorting functionality for the items within the "Actions" and "Conditions" tabs in the `AddModModal`.

Key changes:
- Extracts a new `TabList.vue` component to manage the list of items for each tab.
- Utilizes the `useSortableAndAutoAnimate` composable to enable drag-and-drop sorting with smooth animations.
- Implements persistent sorting using `localStorage` (via `@vueuse/core`'s `useStorage`), ensuring that the custom order is saved independently for both "actions" and "conditions".
- Adds a visual drag handle (`i-lucide-grip-vertical` icon) to each item, which appears on hover to indicate draggable areas.

## Testing
- Verified that items can be reordered by dragging the handle.
- Verified that sorting is persisted across reloads and is isolated between the two different tabs.
- Ran typechecks (`pnpm run typecheck`), linting (`pnpm run lint`), and unit tests (`pnpm run test`), all passing.

---
*PR created automatically by Jules for task [15546692133609970713](https://jules.google.com/task/15546692133609970713) started by @aiktb*