### PR TITLE
build: split tsconfig into app and node

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "postinstall": "wxt prepare",
-    "typecheck": "vue-tsc --noEmit"
+    "typecheck": "vue-tsc --build"
   },
   "dependencies": {
     "@codemirror/lang-json": "catalog:",

--- a/extension/tsconfig.app.json
+++ b/extension/tsconfig.app.json
@@ -1,0 +1,37 @@
+{
+  "extends": "./.wxt/tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "moduleDetection": "force",
+    "libReplacement": false,
+    "rootDir": ".",
+    "types": [
+      "unplugin-turbo-console/client"
+    ],
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": [
+    "./src/**/*",
+    "./src/**/*.vue",
+    "./.wxt/wxt.d.ts"
+  ],
+  "exclude": ["src/**/__TESTS__/*", "./.output"],
+
+  "vueCompilerOptions": {
+    "checkUnknownDirectives": true,
+    "plugins": [
+      "vue-router/volar/sfc-route-blocks",
+      "vue-router/volar/sfc-typed-router"
+    ]
+  }
+}

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,25 +1,11 @@
 {
-  "extends": "./.wxt/tsconfig.json",
-  "compilerOptions": {
-    "jsx": "preserve",
-    "jsxImportSource": "vue",
-    "rootDir": ".",
-    "types": [
-      "unplugin-turbo-console/client"
-    ],
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "esModuleInterop": true
-  },
-  "vueCompilerOptions": {
-    "checkUnknownDirectives": true,
-    "plugins": [
-      "vue-router/volar/sfc-route-blocks",
-      "vue-router/volar/sfc-typed-router"
-    ]
-  }
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "files": []
 }

--- a/extension/tsconfig.node.json
+++ b/extension/tsconfig.node.json
@@ -1,0 +1,25 @@
+// TSConfig for modules that run in Node.js environment via either transpilation or type-stripping.
+{
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "compilerOptions": {
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    // Most tools use transpilation instead of Node.js's native type-stripping.
+    // Bundler mode provides a smoother developer experience.
+    "module": "preserve",
+    "moduleResolution": "bundler",
+
+    // Include Node.js types and avoid accidentally including other `@types/*` packages.
+    "types": ["node", "@wxt-dev/auto-icons"],
+
+    // Disable emitting output during `vue-tsc --build`, which is used for type-checking only.
+    "noEmit": true
+  },
+  "include": [
+    "wxt.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "eslint.config.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@commitlint/cli": "catalog:",
     "@commitlint/config-conventional": "catalog:",
     "@commitlint/types": "catalog:",
+    "@tsconfig/node24": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-better-tailwindcss": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ catalogs:
     '@total-typescript/ts-reset':
       specifier: ^0.6.1
       version: 0.6.1
+    '@tsconfig/node24':
+      specifier: ^24.0.4
+      version: 24.0.4
     '@types/node':
       specifier: ^24.12.0
       version: 24.12.2
@@ -215,6 +218,9 @@ importers:
       '@commitlint/types':
         specifier: 'catalog:'
         version: 20.5.0
+      '@tsconfig/node24':
+        specifier: 'catalog:'
+        version: 24.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
@@ -1896,6 +1902,9 @@ packages:
 
   '@total-typescript/ts-reset@0.6.1':
     resolution: {integrity: sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==}
+
+  '@tsconfig/node24@24.0.4':
+    resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -6789,6 +6798,8 @@ snapshots:
       vue: 3.5.33(typescript@6.0.3)
 
   '@total-typescript/ts-reset@0.6.1': {}
+
+  '@tsconfig/node24@24.0.4': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ catalog:
   "@tanstack/vue-query": ^5.100.2
   "@tanstack/vue-virtual": ^3.13.24
   "@total-typescript/ts-reset": ^0.6.1
+  "@tsconfig/node24": ^24.0.4
   "@types/node": ^24.12.0
   "@types/sortablejs": ^1.15.9
   "@vitejs/plugin-vue": ^6.0.6


### PR DESCRIPTION
Due to the impact of https://github.com/wxt-dev/wxt/issues/1459, this PR does not resolve the issue where `@types/node` is accessible within the `src` directory.