### PR TITLE
fix: auto clean up orphaned DNR rules that are no longer associated with any registerable profile

### DIFF
--- a/extension/src/entrypoints/background/DNR/registerRule.ts
+++ b/extension/src/entrypoints/background/DNR/registerRule.ts
@@ -1,7 +1,7 @@
 import type { ProfileChanges } from "../index";
+import { isEqual } from "es-toolkit";
 import { match, P } from "ts-pattern";
 import { useNativeResourceTypeBehaviorStorage, useProfileId2ErrorMessageRecordStorage, useProfileId2RelatedRuleIdRecordStorage } from "@/lib/storage";
-import { updateBadgeCount } from "./badge";
 import { buildAction } from "./buildAction";
 import { buildCondition } from "./buildCondition";
 
@@ -42,17 +42,16 @@ export async function updateRules(changes: ProfileChanges) {
       profileId2ErrorRecord[result.value.profileId] = String(result.value.error);
     }
   }
-  await Promise.all([
-    handleRegistrationRelatedRuleIdChange({
-      upsertRecord: profileId2RelatedRuleIdRecord,
-      deleteIds: deleteRelatedRuleIds,
-    }),
-    handleRegistrationErrorMessageChange({
-      upsertRecord: profileId2ErrorRecord,
-      deleteIds: deleteErrorMessageIds,
-    }),
-    updateBadgeCount(),
-  ]);
+  // Persist the rule mapping first so reconciliation never races an unfinished
+  // mapping write if the error-record update fails.
+  await handleRegistrationRelatedRuleIdChange({
+    upsertRecord: profileId2RelatedRuleIdRecord,
+    deleteIds: deleteRelatedRuleIds,
+  });
+  await handleRegistrationErrorMessageChange({
+    upsertRecord: profileId2ErrorRecord,
+    deleteIds: deleteErrorMessageIds,
+  });
 }
 
 interface RuleUpdateResult {
@@ -106,9 +105,8 @@ async function upsertRules(changes: Pick<ProfileChanges, "created" | "modified">
       action,
     } as const satisfies Browser.declarativeNetRequest.Rule;
 
-    // For modified profiles, remove old rule first
     const record = await profileId2RelatedRuleIdRecordItem.getValue();
-    const deleteRuleId = changes.modified.includes(profile) ? record[profile.id] : undefined;
+    const deleteRuleId = record[profile.id];
 
     const result = await browser.declarativeNetRequest.updateDynamicRules({
       removeRuleIds: match(deleteRuleId)
@@ -173,4 +171,38 @@ function findMissingPositive(numbers: number[]) {
   let i = 1;
   while (set.has(i)) i++;
   return i;
+}
+
+/**
+ * Repairs the non-atomic boundary between DNR storage and extension storage.
+ *
+ * The service worker can stop after a DNR update succeeds but before the
+ * corresponding profile-to-rule mapping is persisted (or vice versa). DNR
+ * rules survive that restart, so reconcile both sides when the worker starts.
+ */
+export async function reconcileRuleRegistrationState(registerableProfileIds: Iterable<string>) {
+  const [rules, registrationRecord] = await Promise.all([
+    browser.declarativeNetRequest.getDynamicRules(),
+    profileId2RelatedRuleIdRecordItem.getValue(),
+  ]);
+  const existingRuleIds = new Set(rules.map(rule => rule.id));
+  const registerableProfileIdSet = new Set(registerableProfileIds);
+  const validRegistrationRecord = Object.fromEntries(
+    Object.entries(registrationRecord).filter(([profileId, ruleId]) =>
+      registerableProfileIdSet.has(profileId) && existingRuleIds.has(ruleId),
+    ),
+  );
+  const registeredRuleIds = new Set(Object.values(validRegistrationRecord));
+  const unrelatedRuleIds = rules
+    .map(rule => rule.id)
+    .filter(ruleId => !registeredRuleIds.has(ruleId));
+
+  // Keep stale mappings until their rules are definitely gone. If DNR removal
+  // fails, the next worker start can still identify and retry those rules.
+  if (unrelatedRuleIds.length > 0) {
+    await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds: unrelatedRuleIds });
+  }
+  if (!isEqual(registrationRecord, validRegistrationRecord)) {
+    await profileId2RelatedRuleIdRecordItem.setValue(validRegistrationRecord);
+  }
 }

--- a/extension/src/entrypoints/background/DNR/unregisterAllRules.ts
+++ b/extension/src/entrypoints/background/DNR/unregisterAllRules.ts
@@ -6,12 +6,11 @@ const { item: profileId2RelatedRuleIdRecordItem } = useProfileId2RelatedRuleIdRe
 export async function unregisterAllRules() {
   const oldRules = await browser.declarativeNetRequest.getDynamicRules();
   const oldRuleIds = oldRules.map(r => r.id);
-  if (!oldRuleIds.length) {
-    return;
+  if (oldRuleIds.length > 0) {
+    await browser.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: oldRuleIds,
+    });
   }
-  await browser.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: oldRuleIds,
-  });
 
   await Promise.all([
     profileId2ErrorMessageRecordItem.setValue({}),

--- a/extension/src/entrypoints/background/index.ts
+++ b/extension/src/entrypoints/background/index.ts
@@ -5,7 +5,7 @@ import { match, P } from "ts-pattern";
 import { usePowerOnStorage, useProfileManagerStorage } from "@/lib/storage";
 import { setIconAndBadgeForDisabled, updateBadgeWhenRestarted } from "./DNR/badge";
 import { buildAction } from "./DNR/buildAction";
-import { updateRules } from "./DNR/registerRule";
+import { reconcileRuleRegistrationState, updateRules } from "./DNR/registerRule";
 import { unregisterAllRules } from "./DNR/unregisterAllRules";
 import { onMessage } from "./message";
 import { setupSyncCookies } from "./syncCookies";
@@ -47,17 +47,18 @@ export default defineBackground({
           if (changes.deleted.length === 0 && changes.modified.length === 0 && changes.created.length === 0) {
             return;
           }
-          await updateRules(changes);
+          await updateRulesAndReconcile(changes);
         }
       });
     });
     setupSyncCookies({ profileManagerMutex, profileManagerItem });
 
-    // Update the badge when the service worker is restarted, such as toggle extension on/off in chrome://extensions
-    updateBadgeWhenRestarted();
+    // Clean up orphaned DNR rules that are not associated with any profile
+    // whenever the service worker restarts, then update the badge.
+    reconcileRulesAndUpdateBadge();
     // The following two scenarios will not activate the Service Worker, resulting in the loss of the badge.
-    browser.runtime.onStartup.addListener(updateBadgeWhenRestarted);
-    browser.runtime.onInstalled.addListener(updateBadgeWhenRestarted);
+    browser.runtime.onStartup.addListener(reconcileRulesAndUpdateBadge);
+    browser.runtime.onInstalled.addListener(reconcileRulesAndUpdateBadge);
 
     // Manually Recover from a Failure
     onMessage("reinitializeAllRules", () => {
@@ -84,15 +85,47 @@ export default defineBackground({
       await browser.tabs.create({ url: importUrl });
     });
 
+    const getRegisterableProfiles = (profiles: Profile[]) => {
+      return profiles.filter(p => p.enabled && hasNonBlankActionFormValues(p));
+    };
+
     async function treatAllProfilesAsCreated() {
       const manager = await profileManagerItem.getValue();
       // When power on, treat all profiles as created
       const changes = {
         deleted: [],
         modified: [],
-        created: manager.profiles.filter(p => p.enabled && hasNonBlankActionFormValues(p)).map(pickProfileFields),
+        created: getRegisterableProfiles(manager.profiles).map(pickProfileFields),
       } as const satisfies ProfileChanges;
-      await updateRules(changes);
+      await updateRulesAndReconcile(changes);
+    }
+
+    async function updateRulesAndReconcile(changes: ProfileChanges) {
+      try {
+        await updateRules(changes);
+      } finally {
+        await reconcileCurrentRulesAndUpdateBadge();
+      }
+    }
+
+    async function reconcileCurrentRulesAndUpdateBadge() {
+      const manager = await profileManagerItem.getValue();
+      const registerableProfileIds = getRegisterableProfiles(manager.profiles).map(profile => profile.id);
+      await reconcileRuleRegistrationState(registerableProfileIds);
+      await updateBadgeWhenRestarted();
+    }
+
+    function reconcileRulesAndUpdateBadge() {
+      return profileManagerMutex.runExclusive(async () => {
+        if (await powerOnItem.getValue()) {
+          await reconcileCurrentRulesAndUpdateBadge();
+        } else {
+          // Also recover if the worker stopped after power was persisted as off
+          // but before its rules and registration records were removed.
+          await unregisterAllRules();
+          await updateBadgeWhenRestarted();
+        }
+      });
     }
   },
 });


### PR DESCRIPTION
## Summary

Automatically clean up orphaned DNR rules that are no longer associated with any registerable profile.

## Background

DNR rules and the `profileId -> ruleId` mapping are stored separately and cannot be updated atomically.

A full profile re-registration and a queued profile-created storage event could register the same profile twice. The later registration would overwrite the stored mapping, leaving the earlier DNR rule active without an associated profile.

Similar inconsistencies could also remain if the service worker stopped between updating DNR rules and persisting their mappings.

## Changes

- Treat profile creation as an upsert by replacing any existing rule associated with the profile.
- Reconcile DNR rules with the current registerable profiles after every `updateRules()` call.
- Reconcile again whenever the service worker starts as a fallback for interrupted updates.
- Remove DNR rules that have no valid profile mapping.
- Remove mappings whose profile or DNR rule no longer exists.
- Update the badge after reconciliation so orphaned rules are not included in the count.
- Persist rule mappings before registration errors to prevent reconciliation from racing an unfinished mapping write.
- Clear stale registration records even when there are no DNR rules to unregister.
