### PR TITLE
feat(profiles): add keyboard shortcuts for Quick Create and Settings

### DIFF
--- a/extension/src/composables/__TESTS__/useTinykeys.test.ts
+++ b/extension/src/composables/__TESTS__/useTinykeys.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { effectScope } from "vue";
+import { useTinykeys } from "../useTinykeys";
+
+const { stop } = vi.hoisted(() => ({
+  stop: vi.fn(),
+}));
+
+vi.mock("tinykeys", () => ({
+  parseKeybinding: () => [[["Control"], [], "n"]],
+  tinykeys: () => stop,
+}));
+
+describe("useTinykeys", () => {
+  it("removes its listener when the active effect scope is disposed", () => {
+    const scope = effectScope();
+
+    scope.run(() => useTinykeys({} as Window, "$mod+n", vi.fn()));
+    expect(stop).not.toHaveBeenCalled();
+
+    scope.stop();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});

--- a/extension/src/composables/__TESTS__/useTinykeys.test.ts
+++ b/extension/src/composables/__TESTS__/useTinykeys.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { effectScope } from "vue";
 import { useTinykeys } from "../useTinykeys";
 
-const { stop } = vi.hoisted(() => ({
+const { onUnmounted, stop } = vi.hoisted(() => ({
+  onUnmounted: vi.fn(),
   stop: vi.fn(),
 }));
 
@@ -11,14 +11,15 @@ vi.mock("tinykeys", () => ({
   tinykeys: () => stop,
 }));
 
+vi.mock("vue", () => ({
+  onUnmounted,
+}));
+
 describe("useTinykeys", () => {
-  it("removes its listener when the active effect scope is disposed", () => {
-    const scope = effectScope();
+  it("removes its listener when the component is unmounted", () => {
+    useTinykeys({} as Window, "$mod+n", vi.fn());
 
-    scope.run(() => useTinykeys({} as Window, "$mod+n", vi.fn()));
-    expect(stop).not.toHaveBeenCalled();
-
-    scope.stop();
-    expect(stop).toHaveBeenCalledOnce();
+    expect(onUnmounted).toHaveBeenCalledOnce();
+    expect(onUnmounted).toHaveBeenCalledWith(stop);
   });
 });

--- a/extension/src/composables/useTinykeys.ts
+++ b/extension/src/composables/useTinykeys.ts
@@ -1,7 +1,7 @@
 import type { KeybindingHandler } from "tinykeys";
 import { parseKeybinding, tinykeys } from "tinykeys";
 import { match } from "ts-pattern";
-import { onScopeDispose } from "vue";
+import { onUnmounted } from "vue";
 
 export function useTinykeys(
   target: Window | HTMLElement,
@@ -9,7 +9,7 @@ export function useTinykeys(
   handler: KeybindingHandler,
 ) {
   const stop = tinykeys(target, { [keybinding]: handler });
-  onScopeDispose(stop);
+  onUnmounted(stop);
 
   const keys = parseKeybinding(keybinding).flatMap(([requiredModifiers, optionalModifiers, key]) => {
     if (key instanceof RegExp) {

--- a/extension/src/composables/useTinykeys.ts
+++ b/extension/src/composables/useTinykeys.ts
@@ -1,7 +1,7 @@
 import type { KeybindingHandler } from "tinykeys";
 import { parseKeybinding, tinykeys } from "tinykeys";
 import { match } from "ts-pattern";
-import { onUnmounted } from "vue";
+import { onScopeDispose } from "vue";
 
 export function useTinykeys(
   target: Window | HTMLElement,
@@ -9,7 +9,7 @@ export function useTinykeys(
   handler: KeybindingHandler,
 ) {
   const stop = tinykeys(target, { [keybinding]: handler });
-  onUnmounted(stop);
+  onScopeDispose(stop);
 
   const keys = parseKeybinding(keybinding).flatMap(([requiredModifiers, optionalModifiers, key]) => {
     if (key instanceof RegExp) {

--- a/extension/src/entrypoints/popup/pages/profiles/components/Header/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Header/index.vue
@@ -8,6 +8,7 @@ import { Button } from "#/ui/button";
 import {
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuShortcut,
 } from "#/ui/dropdown-menu";
 import {
   Input,
@@ -227,19 +228,15 @@ const undoAndRedoButtonGroup = [
               @click="btn.onClick"
             >
               <span>{{ btn.label }}</span>
-              <KbdGroup class="z-50 ml-auto">
-                <Kbd v-for="key in btn.shortcutKeys" :key>
-                  {{ key }}
-                </Kbd>
-              </KbdGroup>
+              <DropdownMenuShortcut>
+                {{ btn.shortcutKeys.join("+") }}
+              </DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuItem @click="addRuleOptionDialogBus.emit({ target: 'actions' })">
               <span>{{ t("profile.header.addActionOrCondition") }}</span>
-              <KbdGroup class="z-50 ml-auto">
-                <Kbd v-for="key in addRuleOptionShortcutKeys" :key>
-                  {{ key }}
-                </Kbd>
-              </KbdGroup>
+              <DropdownMenuShortcut>
+                {{ addRuleOptionShortcutKeys.join("+") }}
+              </DropdownMenuShortcut>
             </DropdownMenuItem>
           </DropdownMenuGroup>
         </template>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
@@ -130,14 +130,9 @@ function getRuleActionTypeDescription(type: RuleActionType) {
         <DropdownMenuGroup>
           <DropdownMenuItem class="justify-between gap-2" @click="quickCreateProfile">
             <span>{{ t("profile.sidebar.quickCreate") }}</span>
-            <div class="ml-auto flex items-center gap-2">
-              <InfoTooltip
-                :description="t('profile.sidebar.quickCreateDescription')"
-              />
-              <DropdownMenuShortcut class="ml-0">
-                {{ quickCreateShortcutKeys.join("+") }}
-              </DropdownMenuShortcut>
-            </div>
+            <DropdownMenuShortcut>
+              {{ quickCreateShortcutKeys.join("+") }}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
@@ -65,7 +65,7 @@ function openSettings() {
   menuOpen.value = false;
 }
 
-const quickCreateShortcutKeys = useTinykeys(window, "$mod+n", (event) => {
+const quickCreateShortcutKeys = useTinykeys(window, "$mod+N", (event) => {
   event.preventDefault();
   if (!event.repeat) {
     quickCreateProfile();

--- a/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
@@ -5,6 +5,7 @@ import { useStorage } from "@vueuse/core";
 import { match } from "ts-pattern";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
 import InfoTooltip from "#/components/InfoTooltip.vue";
 import { useRuleActionType } from "#/composables/useRuleActionType";
 import Badge from "#/ui/badge/Badge.vue";
@@ -21,6 +22,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "#/ui/dropdown-menu";
+import { Kbd, KbdGroup } from "#/ui/kbd";
 import { Label } from "#/ui/label";
 import { Switch } from "#/ui/switch";
 import {
@@ -29,6 +31,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "#/ui/tooltip";
+import { useTinykeys } from "@/composables/useTinykeys";
 import { useProfilesStore } from "@/entrypoints/popup/stores/useProfilesStore";
 import { useSettingsStore } from "@/entrypoints/popup/stores/useSettingsStore";
 import { cn } from "@/lib/utils";
@@ -41,6 +44,7 @@ const { class: className } = defineProps<{
 const profilesStore = useProfilesStore();
 const settingsStore = useSettingsStore();
 const { t } = useI18n();
+const router = useRouter();
 const ruleActionTypeMap = useRuleActionType();
 
 const defaultRuleActionType = useStorage<RuleActionType>("default-rule-action-type", "modifyHeaders");
@@ -50,6 +54,30 @@ function openInFullscreen() {
 }
 
 const menuOpen = ref(false);
+
+function quickCreateProfile() {
+  void profilesStore.addProfile(defaultRuleActionType.value);
+  menuOpen.value = false;
+}
+
+function openSettings() {
+  void router.push("/settings");
+  menuOpen.value = false;
+}
+
+const quickCreateShortcutKeys = useTinykeys(window, "$mod+n", (event) => {
+  event.preventDefault();
+  if (!event.repeat) {
+    quickCreateProfile();
+  }
+});
+
+const settingsShortcutKeys = useTinykeys(window, "$mod+,", (event) => {
+  event.preventDefault();
+  if (!event.repeat) {
+    openSettings();
+  }
+});
 
 const ruleActionTypes = [
   "modifyHeaders",
@@ -100,11 +128,18 @@ function getRuleActionTypeDescription(type: RuleActionType) {
       </DropdownMenuTrigger>
       <DropdownMenuContent class="min-w-40" align="end" :collision-padding="8">
         <DropdownMenuGroup>
-          <DropdownMenuItem class="justify-between gap-1" @click="profilesStore.addProfile(defaultRuleActionType)">
-            {{ t("profile.sidebar.quickCreate") }}
-            <InfoTooltip
-              :description="t('profile.sidebar.quickCreateDescription')"
-            />
+          <DropdownMenuItem class="justify-between gap-2" @click="quickCreateProfile">
+            <span>{{ t("profile.sidebar.quickCreate") }}</span>
+            <div class="ml-auto flex items-center gap-2">
+              <InfoTooltip
+                :description="t('profile.sidebar.quickCreateDescription')"
+              />
+              <KbdGroup>
+                <Kbd v-for="key in quickCreateShortcutKeys" :key>
+                  {{ key }}
+                </Kbd>
+              </KbdGroup>
+            </div>
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
@@ -163,10 +198,13 @@ function getRuleActionTypeDescription(type: RuleActionType) {
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
-          <DropdownMenuItem as-child>
-            <RouterLink to="/settings">
-              {{ t("common.settings") }}
-            </RouterLink>
+          <DropdownMenuItem class="gap-2" @click="openSettings">
+            <span>{{ t("common.settings") }}</span>
+            <KbdGroup class="ml-auto">
+              <Kbd v-for="key in settingsShortcutKeys" :key>
+                {{ key }}
+              </Kbd>
+            </KbdGroup>
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>

--- a/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/Sidebar/index.vue
@@ -17,12 +17,12 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "#/ui/dropdown-menu";
-import { Kbd, KbdGroup } from "#/ui/kbd";
 import { Label } from "#/ui/label";
 import { Switch } from "#/ui/switch";
 import {
@@ -134,11 +134,9 @@ function getRuleActionTypeDescription(type: RuleActionType) {
               <InfoTooltip
                 :description="t('profile.sidebar.quickCreateDescription')"
               />
-              <KbdGroup>
-                <Kbd v-for="key in quickCreateShortcutKeys" :key>
-                  {{ key }}
-                </Kbd>
-              </KbdGroup>
+              <DropdownMenuShortcut class="ml-0">
+                {{ quickCreateShortcutKeys.join("+") }}
+              </DropdownMenuShortcut>
             </div>
           </DropdownMenuItem>
           <DropdownMenuSub>
@@ -200,11 +198,9 @@ function getRuleActionTypeDescription(type: RuleActionType) {
         <DropdownMenuGroup>
           <DropdownMenuItem class="gap-2" @click="openSettings">
             <span>{{ t("common.settings") }}</span>
-            <KbdGroup class="ml-auto">
-              <Kbd v-for="key in settingsShortcutKeys" :key>
-                {{ key }}
-              </Kbd>
-            </KbdGroup>
+            <DropdownMenuShortcut>
+              {{ settingsShortcutKeys.join("+") }}
+            </DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>


### PR DESCRIPTION
## Summary

- add `$mod+n` as the Quick Create shortcut
- add `$mod+,` as the Settings shortcut
- display platform-aware shortcut keys in the sidebar dropdown
- dispose shortcut listeners with their Vue effect scope to avoid duplicate handling after hot reloads

## Why

Make common profile creation and navigation actions accessible from the keyboard while keeping the shortcuts discoverable.

## User impact

Users can use Command on macOS or Ctrl on other platforms. Repeated key events are ignored and matching browser defaults are prevented.

## Validation

- `pnpm run lint:fix`
- `pnpm run typecheck`
- `pnpm run test` (55 tests passed)
