### PR TITLE
fix: save user input when closing popup with Esc or clicking outside

### DIFF
--- a/extension/src/composables/useRecentHeaderNames.ts
+++ b/extension/src/composables/useRecentHeaderNames.ts
@@ -2,7 +2,7 @@ import type { Ref } from "vue";
 import type { ActionType } from "@/lib/types";
 import { useLocalStorage } from "@vueuse/core";
 
-const RECENT_HEADER_NAMES_LIMIT = 4;
+const RECENT_HEADER_NAMES_LIMIT = 3;
 const RECENT_HEADER_NAMES_STORAGE_KEYS = {
   request: "recent-request-header-names",
   response: "recent-response-header-names",

--- a/extension/src/composables/useRecentHeaderNames.ts
+++ b/extension/src/composables/useRecentHeaderNames.ts
@@ -14,11 +14,12 @@ export function addNameToRecentHeaderNames(recentHeaderNames: string[], name: st
   if (!normalizedName)
     return recentHeaderNames;
 
+  if (recentHeaderNames.some(recentName => recentName.toLocaleLowerCase() === normalizedName))
+    return recentHeaderNames;
+
   return [
     normalizedName,
-    ...recentHeaderNames.filter(
-      recentName => recentName.toLocaleLowerCase() !== normalizedName,
-    ),
+    ...recentHeaderNames,
   ].slice(0, RECENT_HEADER_NAMES_LIMIT);
 }
 

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import type { AutoAnimationPlugin } from "@formkit/auto-animate";
+import autoAnimate from "@formkit/auto-animate";
 import { AnimatePresence, motion } from "motion-v";
+import { onBeforeUnmount, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "#/ui/button";
 import { cn } from "@/lib/utils";
@@ -15,6 +18,41 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+
+const tagAnimation: AutoAnimationPlugin = (element, action, newCoordinates, oldCoordinates) => {
+  const timing = { duration: 160, easing: "ease-out" };
+
+  if (action === "add") {
+    return new KeyframeEffect(element, [
+      { opacity: 0, transform: "translateX(-4px) scale(0.98)" },
+      { opacity: 1, transform: "translateX(0) scale(1)" },
+    ], timing);
+  }
+
+  if (action === "remove") {
+    return new KeyframeEffect(element, [
+      { opacity: 1, transform: "scale(1)" },
+      { opacity: 0, transform: "scale(0.98)" },
+    ], timing);
+  }
+
+  const previous = oldCoordinates!;
+  const current = newCoordinates!;
+  return new KeyframeEffect(element, [
+    { transform: `translate(${previous.left - current.left}px, ${previous.top - current.top}px)` },
+    { transform: "translate(0, 0)" },
+  ], timing);
+};
+
+const tagsContainer = useTemplateRef<HTMLDivElement>("tagsContainer");
+let tagsAnimationController: ReturnType<typeof autoAnimate> | undefined;
+
+watch(tagsContainer, (element) => {
+  tagsAnimationController?.destroy?.();
+  tagsAnimationController = element ? autoAnimate(element, tagAnimation) : undefined;
+}, { flush: "post" });
+
+onBeforeUnmount(() => tagsAnimationController?.destroy?.());
 </script>
 
 <template>
@@ -36,7 +74,7 @@ const { t } = useI18n();
       >
         <div class="flex items-center gap-1">
           <span class="sr-only">{{ t("headerMod.recent.title") }}</span>
-          <div v-auto-animate class="flex flex-wrap gap-1">
+          <div ref="tagsContainer" class="flex flex-wrap gap-1">
             <div
               v-for="name in names"
               :key="name"

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import type { AutoAnimationPlugin } from "@formkit/auto-animate";
-import autoAnimate from "@formkit/auto-animate";
 import { AnimatePresence, motion } from "motion-v";
-import { onBeforeUnmount, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "#/ui/button";
 import { cn } from "@/lib/utils";
@@ -18,41 +15,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-
-const tagAnimation: AutoAnimationPlugin = (element, action, newCoordinates, oldCoordinates) => {
-  const timing = { duration: 160, easing: "ease-out" };
-
-  if (action === "add") {
-    return new KeyframeEffect(element, [
-      { opacity: 0, transform: "translateX(-4px) scale(0.98)" },
-      { opacity: 1, transform: "translateX(0) scale(1)" },
-    ], timing);
-  }
-
-  if (action === "remove") {
-    return new KeyframeEffect(element, [
-      { opacity: 1, transform: "scale(1)" },
-      { opacity: 0, transform: "scale(0.98)" },
-    ], timing);
-  }
-
-  const previous = oldCoordinates!;
-  const current = newCoordinates!;
-  return new KeyframeEffect(element, [
-    { transform: `translate(${previous.left - current.left}px, ${previous.top - current.top}px)` },
-    { transform: "translate(0, 0)" },
-  ], timing);
-};
-
-const tagsContainer = useTemplateRef<HTMLDivElement>("tagsContainer");
-let tagsAnimationController: ReturnType<typeof autoAnimate> | undefined;
-
-watch(tagsContainer, (element) => {
-  tagsAnimationController?.destroy?.();
-  tagsAnimationController = element ? autoAnimate(element, tagAnimation) : undefined;
-}, { flush: "post" });
-
-onBeforeUnmount(() => tagsAnimationController?.destroy?.());
 </script>
 
 <template>
@@ -74,7 +36,7 @@ onBeforeUnmount(() => tagsAnimationController?.destroy?.());
       >
         <div class="flex items-center gap-1">
           <span class="sr-only">{{ t("headerMod.recent.title") }}</span>
-          <div ref="tagsContainer" class="flex flex-wrap gap-1">
+          <div v-auto-animate class="flex flex-wrap gap-1">
             <div
               v-for="name in names"
               :key="name"

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
@@ -34,25 +34,23 @@ const { t } = useI18n();
       <div
         :class="cn(`flex min-h-6 items-center border-none`, props.class)"
       >
-        <div class="flex items-center gap-1">
+        <div class="flex w-full items-center gap-1">
           <span class="sr-only">{{ t("headerMod.recent.title") }}</span>
-          <div v-auto-animate class="flex flex-wrap gap-1">
-            <div
+          <div v-auto-animate class="w-full gap-1 space-x-1">
+            <span
               v-for="name in names"
               :key="name"
-              class="
-                group/recent relative max-w-30 shrink-0
-                xl:max-w-40
-              "
+              class="group/recent relative shrink-0"
             >
               <Button
                 type="button"
                 size="sm"
                 variant="secondary"
                 class="
-                  h-6 w-full justify-start rounded-full py-0 pr-6 pl-3.5 text-sm
-                  font-normal text-muted-foreground shadow-none
+                  h-6 max-w-30 justify-start rounded-full py-0 pr-6 pl-3.5
+                  text-sm font-normal text-muted-foreground shadow-none
                   hover:text-foreground
+                  xl:max-w-40
                 "
                 :aria-label="t('headerMod.recent.add', { name })"
                 @click="emit('add', name)"
@@ -75,7 +73,7 @@ const { t } = useI18n();
                 <i class="i-lucide-x size-3" />
                 <span class="sr-only">{{ t('headerMod.recent.remove', { name }) }}</span>
               </Button>
-            </div>
+            </span>
           </div>
         </div>
       </div>

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { AnimatePresence, motion } from "motion-v";
 import { useI18n } from "vue-i18n";
 import { Button } from "#/ui/button";
 import { cn } from "@/lib/utils";
@@ -18,65 +17,50 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <AnimatePresence :initial="false">
-    <motion.div
-      v-if="names.length > 0"
-      key="recent-header-names"
-      class="w-full overflow-hidden"
-      :initial="{ height: 0, opacity: 0 }"
-      :animate="{ height: 'auto', opacity: 1 }"
-      :exit="{ height: 0, opacity: 0 }"
-      :transition="{
-        height: { duration: 0.16, ease: 'easeOut' },
-        opacity: { duration: 0.12, ease: 'easeOut' },
-      }"
-    >
-      <div
-        :class="cn(`flex min-h-6 items-center border-none`, props.class)"
-      >
-        <div class="flex w-full items-center gap-1">
-          <span class="sr-only">{{ t("headerMod.recent.title") }}</span>
-          <div v-auto-animate class="w-full gap-1 space-x-1">
-            <span
-              v-for="name in names"
-              :key="name"
-              class="group/recent relative shrink-0"
-            >
-              <Button
-                type="button"
-                size="sm"
-                variant="secondary"
-                class="
-                  h-6 max-w-30 justify-start rounded-full py-0 pr-6 pl-3.5
-                  text-sm font-normal text-muted-foreground shadow-none
-                  hover:text-foreground
-                  xl:max-w-40
-                "
-                :aria-label="t('headerMod.recent.add', { name })"
-                @click="emit('add', name)"
-              >
-                <span class="truncate">{{ name }}</span>
-              </Button>
-              <Button
-                type="button"
-                size="icon-xs"
-                variant="ghost"
-                class="
-                  absolute top-1/2 right-1 size-4 -translate-y-1/2 rounded-full
-                  text-muted-foreground/70
-                  hover:bg-primary/15 hover:text-primary
-                  focus-visible:bg-destructive/15 focus-visible:text-destructive
-                  focus-visible:ring-1 focus-visible:ring-destructive/40
-                "
-                @click="emit('remove', name)"
-              >
-                <i class="i-lucide-x size-3" />
-                <span class="sr-only">{{ t('headerMod.recent.remove', { name }) }}</span>
-              </Button>
-            </span>
-          </div>
-        </div>
+  <div
+    :class="cn(`flex items-center border-none`, props.class)"
+  >
+    <div class="flex w-full items-center gap-1">
+      <span class="sr-only">{{ t("headerMod.recent.title") }}</span>
+      <div v-auto-animate class="w-full gap-1 space-x-1">
+        <span
+          v-for="name in names"
+          :key="name"
+          class="group/recent relative shrink-0"
+        >
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            class="
+              h-6 max-w-30 justify-start rounded-full py-0 pr-6 pl-3.5 text-sm
+              font-normal text-muted-foreground shadow-none
+              hover:text-foreground
+              xl:max-w-40
+            "
+            :aria-label="t('headerMod.recent.add', { name })"
+            @click="emit('add', name)"
+          >
+            <span class="truncate">{{ name }}</span>
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            class="
+              absolute top-1/2 right-1 size-4 -translate-y-1/2 rounded-full
+              text-muted-foreground/70
+              hover:bg-primary/15 hover:text-primary
+              focus-visible:bg-destructive/15 focus-visible:text-destructive
+              focus-visible:ring-1 focus-visible:ring-destructive/40
+            "
+            @click="emit('remove', name)"
+          >
+            <i class="i-lucide-x size-3" />
+            <span class="sr-only">{{ t('headerMod.recent.remove', { name }) }}</span>
+          </Button>
+        </span>
       </div>
-    </motion.div>
-  </AnimatePresence>
+    </div>
+  </div>
 </template>

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RecentHeaderNames.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { AnimatePresence, motion } from "motion-v";
-import { ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "#/ui/button";
 import { cn } from "@/lib/utils";
@@ -16,25 +15,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const displayedNames = ref([...props.names]);
-const suppressTagAnimations = ref(false);
-
-watch(
-  () => props.names,
-  (names, previousNames) => {
-    suppressTagAnimations.value = (names.length === 0) !== (previousNames.length === 0);
-
-    // Keep the final item mounted while the whole alert exits so the item and
-    // alert exit animations do not run at the same time.
-    if (names.length > 0)
-      displayedNames.value = [...names];
-  },
-);
-
-function handleContainerAnimationComplete() {
-  if (props.names.length > 0)
-    suppressTagAnimations.value = false;
-}
 </script>
 
 <template>
@@ -50,64 +30,52 @@ function handleContainerAnimationComplete() {
         height: { duration: 0.16, ease: 'easeOut' },
         opacity: { duration: 0.12, ease: 'easeOut' },
       }"
-      @animation-complete="handleContainerAnimationComplete"
     >
       <div
-        :class="cn(`flex items-center border-none`, props.class)"
+        :class="cn(`flex min-h-6 items-center border-none`, props.class)"
       >
         <div class="flex items-center gap-1">
           <span class="sr-only">{{ t("headerMod.recent.title") }}</span>
-          <div class="flex flex-wrap gap-1">
-            <AnimatePresence :initial="false">
-              <motion.div
-                v-for="name in displayedNames"
-                :key="name"
+          <div v-auto-animate class="flex flex-wrap gap-1">
+            <div
+              v-for="name in names"
+              :key="name"
+              class="
+                group/recent relative max-w-30 shrink-0
+                xl:max-w-40
+              "
+            >
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
                 class="
-                  group/recent relative max-w-30 shrink-0
-                  xl:max-w-40
+                  h-6 w-full justify-start rounded-full py-0 pr-6 pl-3.5 text-sm
+                  font-normal text-muted-foreground shadow-none
+                  hover:text-foreground
                 "
-                :initial="suppressTagAnimations
-                  ? false
-                  : { opacity: 0, scale: 0.96, x: -2 }"
-                :animate="{ opacity: 1, scale: 1, x: 0 }"
-                :exit="{ opacity: 0, scale: 0.96, x: -4 }"
-                :transition="suppressTagAnimations
-                  ? { duration: 0 }
-                  : { duration: 0.16, ease: 'easeOut' }"
+                :aria-label="t('headerMod.recent.add', { name })"
+                @click="emit('add', name)"
               >
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  class="
-                    h-6 w-full justify-start rounded-full py-0 pr-6 pl-3.5
-                    text-sm font-normal text-muted-foreground shadow-none
-                    hover:text-foreground
-                  "
-                  :aria-label="t('headerMod.recent.add', { name })"
-                  @click="emit('add', name)"
-                >
-                  <span class="truncate">{{ name }}</span>
-                </Button>
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  class="
-                    absolute top-1/2 right-1 size-4 -translate-y-1/2
-                    rounded-full text-muted-foreground/70
-                    hover:bg-primary/15 hover:text-primary
-                    focus-visible:bg-destructive/15
-                    focus-visible:text-destructive focus-visible:ring-1
-                    focus-visible:ring-destructive/40
-                  "
-                  @click="emit('remove', name)"
-                >
-                  <i class="i-lucide-x size-3" />
-                  <span class="sr-only">{{ t('headerMod.recent.remove', { name }) }}</span>
-                </Button>
-              </motion.div>
-            </AnimatePresence>
+                <span class="truncate">{{ name }}</span>
+              </Button>
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                class="
+                  absolute top-1/2 right-1 size-4 -translate-y-1/2 rounded-full
+                  text-muted-foreground/70
+                  hover:bg-primary/15 hover:text-primary
+                  focus-visible:bg-destructive/15 focus-visible:text-destructive
+                  focus-visible:ring-1 focus-visible:ring-destructive/40
+                "
+                @click="emit('remove', name)"
+              >
+                <i class="i-lucide-x size-3" />
+                <span class="sr-only">{{ t('headerMod.recent.remove', { name }) }}</span>
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RedirectUrlGroup.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RedirectUrlGroup.vue
@@ -59,7 +59,7 @@ function deleteGroup() {
       >
         <div class="flex w-full flex-1">
           <Input
-            v-model.trim.lazy="list[index]!.value"
+            v-model.trim="list[index]!.value"
             type="url"
             placeholder="https://example.com/"
           />

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -59,6 +59,10 @@ function normalizeAndCommitHeaderName(name: string) {
     emitRecentHeaderName(field.value.name);
 }
 
+function handleHeaderNameInput(event: Event) {
+  normalizeAndCommitHeaderName((event.target as HTMLInputElement).value);
+}
+
 function getAutocompleteList(actionType: ActionType, operation: HeaderModOperation) {
   if (actionType === "response") {
     return AUTOCOMPLETE_RESPONSE_FIELDS;
@@ -114,7 +118,6 @@ function getOperationLabel(operation: HeaderModOperation) {
         <Combobox
           :model-value="field.name"
           :class="cn('flex-1', field.operation === 'remove' && `col-span-2`)"
-          @update:model-value="normalizeAndCommitHeaderName"
         >
           <ComboboxAnchor class="w-full">
             <ComboboxInput
@@ -122,7 +125,7 @@ function getOperationLabel(operation: HeaderModOperation) {
               :placeholder="t('common.name')"
               class="w-full"
               :class="field.operation !== 'remove' && 'sm:rounded-r-none'"
-              @update:model-value="normalizeAndCommitHeaderName"
+              @input="handleHeaderNameInput"
             />
           </ComboboxAnchor>
 
@@ -132,6 +135,7 @@ function getOperationLabel(operation: HeaderModOperation) {
                 v-for="option in autocompleteList"
                 :key="option"
                 :value="option"
+                @select="normalizeAndCommitHeaderName(option)"
               >
                 {{ option }}
               </ComboboxItem>

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -119,10 +119,11 @@ function getOperationLabel(operation: HeaderModOperation) {
         >
           <ComboboxAnchor class="w-full">
             <ComboboxInput
-              v-model="field.name"
+              :model-value="field.name"
               :placeholder="t('common.name')"
               class="w-full"
               :class="field.operation !== 'remove' && 'sm:rounded-r-none'"
+              @update:model-value="normalizeAndCommitHeaderName"
             />
           </ComboboxAnchor>
 

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { AcceptableValue } from "reka-ui";
 import type { HeaderMod } from "@/lib/schema";
 
 import type { ActionType, HeaderModOperation } from "@/lib/types";
@@ -55,9 +54,8 @@ function normalizeAndCommitHeaderName(name: string) {
     emit("nameCommitted", field.value.name);
 }
 
-function selectAutocompleteOption(value: AcceptableValue) {
-  if (typeof value === "string")
-    normalizeAndCommitHeaderName(value);
+function selectAutocompleteOption(value: string) {
+  normalizeAndCommitHeaderName(value);
 }
 
 function getAutocompleteList(actionType: ActionType, operation: HeaderModOperation) {

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -2,6 +2,7 @@
 import type { HeaderMod } from "@/lib/schema";
 
 import type { ActionType, HeaderModOperation } from "@/lib/types";
+import { useDebounceFn } from "@vueuse/core";
 import { match } from "ts-pattern";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -48,14 +49,14 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
+const emitRecentHeaderName = useDebounceFn((name: string) => {
+  emit("nameCommitted", name);
+}, 200);
+
 function normalizeAndCommitHeaderName(name: string) {
   field.value.name = name.trim().toLocaleLowerCase();
   if (field.value.name)
-    emit("nameCommitted", field.value.name);
-}
-
-function selectAutocompleteOption(value: string) {
-  normalizeAndCommitHeaderName(value);
+    emitRecentHeaderName(field.value.name);
 }
 
 function getAutocompleteList(actionType: ActionType, operation: HeaderModOperation) {
@@ -113,7 +114,7 @@ function getOperationLabel(operation: HeaderModOperation) {
         <Combobox
           :model-value="field.name"
           :class="cn('flex-1', field.operation === 'remove' && `col-span-2`)"
-          @update:model-value="selectAutocompleteOption"
+          @update:model-value="normalizeAndCommitHeaderName"
         >
           <ComboboxAnchor class="w-full">
             <ComboboxInput

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -48,28 +48,15 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-let selectingAutocompleteOption: boolean = false;
-
 function normalizeAndCommitHeaderName(name: string) {
   field.value.name = name.trim().toLocaleLowerCase();
   if (field.value.name)
     emit("nameCommitted", field.value.name);
 }
 
-function commitHeaderName() {
-  if (!selectingAutocompleteOption)
-    normalizeAndCommitHeaderName(field.value.name);
-}
-
-function startSelectingAutocompleteOption() {
-  selectingAutocompleteOption = true;
-}
-
 function selectAutocompleteOption(value: unknown) {
   if (typeof value === "string")
     normalizeAndCommitHeaderName(value);
-
-  selectingAutocompleteOption = false;
 }
 
 function getAutocompleteList(actionType: ActionType, operation: HeaderModOperation) {
@@ -135,7 +122,6 @@ function getOperationLabel(operation: HeaderModOperation) {
               :placeholder="t('common.name')"
               class="w-full"
               :class="field.operation !== 'remove' && 'sm:rounded-r-none'"
-              @change="commitHeaderName"
             />
           </ComboboxAnchor>
 
@@ -145,7 +131,6 @@ function getOperationLabel(operation: HeaderModOperation) {
                 v-for="option in autocompleteList"
                 :key="option"
                 :value="option"
-                @pointerdown="startSelectingAutocompleteOption"
               >
                 {{ option }}
               </ComboboxItem>
@@ -154,7 +139,7 @@ function getOperationLabel(operation: HeaderModOperation) {
         </Combobox>
         <div v-if="field.operation !== 'remove'" class="flex-1">
           <Input
-            v-model.trim.lazy="field.value"
+            v-model.trim="field.value"
             type="text"
             :placeholder="t('common.value')"
             class="sm:rounded-l-none"

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import type { AcceptableValue } from "reka-ui";
 import type { HeaderMod } from "@/lib/schema";
-import type { ActionType, HeaderModOperation } from "@/lib/types";
 
+import type { ActionType, HeaderModOperation } from "@/lib/types";
 import { match } from "ts-pattern";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -54,7 +55,7 @@ function normalizeAndCommitHeaderName(name: string) {
     emit("nameCommitted", field.value.name);
 }
 
-function selectAutocompleteOption(value: unknown) {
+function selectAutocompleteOption(value: AcceptableValue) {
   if (typeof value === "string")
     normalizeAndCommitHeaderName(value);
 }

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/ActionGroup/RequestModFieldWithActions.vue
@@ -51,7 +51,7 @@ const { t } = useI18n();
 
 const emitRecentHeaderName = useDebounceFn((name: string) => {
   emit("nameCommitted", name);
-}, 200);
+}, 500);
 
 function normalizeAndCommitHeaderName(name: string) {
   field.value.name = name.trim().toLocaleLowerCase();

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/SyncCookieGroup/CookieFieldWithActions.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/components/SyncCookieGroup/CookieFieldWithActions.vue
@@ -93,8 +93,8 @@ const cookieOptions = computed(() => {
   return sortBy(options, ["label", "domain", "path"]);
 });
 
-function handleDomainChange(e: Event) {
-  const userInput = (e.target as HTMLInputElement).value.trim();
+function updateDomain(value: string) {
+  const userInput = value.trim();
   try {
     const url = new URL(userInput);
     field.value.domain = url.hostname;
@@ -153,7 +153,7 @@ const missedCookieOptionKey = computed(() => {
           :model-value="field.domain"
           :placeholder="t('common.domain')"
           class="sm:rounded-r-none"
-          @change="handleDomainChange"
+          @update:model-value="updateDomain"
         />
         <div class="relative">
           <Select

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/DomainsFilter.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/DomainsFilter.vue
@@ -152,7 +152,6 @@ const { currentUrl, canUseCurrentUrl } = useCurrentTabUrl();
       >
         <Input
           :model-value="domainsFilter.items[index]!.value"
-          :model-modifiers="{ lazy: true }"
           placeholder="example.com"
           class="w-full"
           @update:model-value="(value) => {

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/UrlOrRegexFilter.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/UrlOrRegexFilter.vue
@@ -152,7 +152,7 @@ function getCurrentTabHost() {
         "
       >
         <Input
-          v-model.trim.lazy="list[index]!.value"
+          v-model.trim="list[index]!.value"
           :placeholder="field[filterType].placeholder"
         />
         <div class="flex gap-0.5">

--- a/extension/src/entrypoints/popup/ui/combobox/Combobox.vue
+++ b/extension/src/entrypoints/popup/ui/combobox/Combobox.vue
@@ -1,9 +1,9 @@
-<script setup lang="ts">
-import type { ComboboxRootEmits, ComboboxRootProps } from "reka-ui";
+<script setup lang="ts" generic="T extends AcceptableValue">
+import type { AcceptableValue, ComboboxRootEmits, ComboboxRootProps } from "reka-ui";
 import { ComboboxRoot, useForwardPropsEmits } from "reka-ui";
 
-const props = defineProps<ComboboxRootProps>();
-const emits = defineEmits<ComboboxRootEmits>();
+const props = defineProps<ComboboxRootProps<T>>();
+const emits = defineEmits<ComboboxRootEmits<T>>();
 
 const forwarded = useForwardPropsEmits(props, emits);
 </script>

--- a/extension/src/entrypoints/popup/ui/input/Input.vue
+++ b/extension/src/entrypoints/popup/ui/input/Input.vue
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 const props = withDefaults(defineProps<{
   defaultValue?: string;
   modelValue?: string;
-  modelModifiers?: { lazy?: boolean; trim?: boolean };
+  modelModifiers?: { trim?: boolean };
   class?: HTMLAttributes["class"];
 }>(), {
   modelModifiers: () => ({}),
@@ -58,7 +58,6 @@ defineExpose({
       `,
       props.class,
     )"
-    @input="!modelModifiers.lazy && emitUpdate($event)"
-    @change="modelModifiers.lazy && emitUpdate($event)"
+    @input="emitUpdate($event)"
   >
 </template>


### PR DESCRIPTION
## Summary

- update profile inputs immediately instead of waiting for blur/change
- ensure input is persisted when the popup closes via Esc or an outside click

## Root cause

Several profile inputs deferred their model update until blur/change. Closing the popup before that event meant the latest user input was never written to storage.

## Validation

- `pnpm run lint:fix`
- `pnpm run typecheck`
- `pnpm run test`
