### PR TITLE
fix: restrict allowAllRequests resource types and remove native DNR setting

### DIFF
--- a/extension/src/entrypoints/background/DNR/buildCondition.ts
+++ b/extension/src/entrypoints/background/DNR/buildCondition.ts
@@ -1,13 +1,8 @@
 import type { ProfileCoreData } from "../diffProfiles";
 import { union, uniq } from "es-toolkit";
 import { match } from "ts-pattern";
-import { ALLOW_ALL_REQUESTS_RESOURCE_TYPES } from "@/lib/schema";
 
-interface BuildConditionOptions {
-  nativeResourceTypeBehavior: boolean;
-}
-
-export function buildCondition(profile: ProfileCoreData, options: BuildConditionOptions) {
+export function buildCondition(profile: ProfileCoreData) {
   const condition: Browser.declarativeNetRequest.RuleCondition = {};
 
   function appendTabIds(key: "tabIds" | "excludedTabIds", tabIds: number[] | undefined) {
@@ -22,11 +17,8 @@ export function buildCondition(profile: ProfileCoreData, options: BuildCondition
         const enabledItems = profile.filters[k]?.items
           .filter(item => item.enabled)
           .flatMap(item => item.value);
-        const resourceTypes = profile.ruleActionType === "allowAllRequests"
-          ? enabledItems?.filter(value => ALLOW_ALL_REQUESTS_RESOURCE_TYPES.includes(value))
-          : enabledItems;
-        if (resourceTypes && resourceTypes.length > 0) {
-          condition[k] = uniq(resourceTypes);
+        if (enabledItems && enabledItems.length > 0) {
+          condition[k] = uniq(enabledItems);
         }
       })
       .with("requestMethods", "excludedRequestMethods", (k) => {
@@ -97,15 +89,11 @@ export function buildCondition(profile: ProfileCoreData, options: BuildCondition
   const hasResourceTypes = condition.resourceTypes !== undefined;
   const hasExcludedResourceTypes = condition.excludedResourceTypes !== undefined;
 
-  if (!hasResourceTypes && !hasExcludedResourceTypes && !options.nativeResourceTypeBehavior) {
+  if (!hasResourceTypes && !hasExcludedResourceTypes && profile.ruleActionType !== "allowAllRequests") {
     // If no resource types are specified, match all types.
     // Setting resource types to "undefined" is too limiting; setting it to "all" can improve extension usability.
     const resourceTypes = Object.values(browser.declarativeNetRequest.ResourceType);
-    // DNR restricts allowAllRequests rules to main_frame/sub_frame resource types.
-    // Using all resource types with allowAllRequests causes rule registration to fail.
-    condition.resourceTypes = match(profile.ruleActionType)
-      .with("allowAllRequests", () => ALLOW_ALL_REQUESTS_RESOURCE_TYPES)
-      .otherwise(() => resourceTypes);
+    condition.resourceTypes = resourceTypes;
   }
 
   // Always exclude the extension itself from its own rules to prevent lockout.

--- a/extension/src/entrypoints/background/DNR/buildCondition.ts
+++ b/extension/src/entrypoints/background/DNR/buildCondition.ts
@@ -1,16 +1,11 @@
 import type { ProfileCoreData } from "../diffProfiles";
-import type { ResourceType } from "@/lib/schema";
 import { union, uniq } from "es-toolkit";
 import { match } from "ts-pattern";
+import { ALLOW_ALL_REQUESTS_RESOURCE_TYPES } from "@/lib/schema";
 
 interface BuildConditionOptions {
   nativeResourceTypeBehavior: boolean;
 }
-
-const allowAllRequestsResourceTypes = [
-  "main_frame",
-  "sub_frame",
-] as const satisfies ResourceType[];
 
 export function buildCondition(profile: ProfileCoreData, options: BuildConditionOptions) {
   const condition: Browser.declarativeNetRequest.RuleCondition = {};
@@ -27,8 +22,11 @@ export function buildCondition(profile: ProfileCoreData, options: BuildCondition
         const enabledItems = profile.filters[k]?.items
           .filter(item => item.enabled)
           .flatMap(item => item.value);
-        if (enabledItems && enabledItems.length > 0) {
-          condition[k] = uniq(enabledItems);
+        const resourceTypes = profile.ruleActionType === "allowAllRequests"
+          ? enabledItems?.filter(value => ALLOW_ALL_REQUESTS_RESOURCE_TYPES.includes(value))
+          : enabledItems;
+        if (resourceTypes && resourceTypes.length > 0) {
+          condition[k] = uniq(resourceTypes);
         }
       })
       .with("requestMethods", "excludedRequestMethods", (k) => {
@@ -106,7 +104,7 @@ export function buildCondition(profile: ProfileCoreData, options: BuildCondition
     // DNR restricts allowAllRequests rules to main_frame/sub_frame resource types.
     // Using all resource types with allowAllRequests causes rule registration to fail.
     condition.resourceTypes = match(profile.ruleActionType)
-      .with("allowAllRequests", () => allowAllRequestsResourceTypes)
+      .with("allowAllRequests", () => ALLOW_ALL_REQUESTS_RESOURCE_TYPES)
       .otherwise(() => resourceTypes);
   }
 

--- a/extension/src/entrypoints/background/DNR/registerRule.ts
+++ b/extension/src/entrypoints/background/DNR/registerRule.ts
@@ -3,7 +3,7 @@ import type { RuleScope } from "../profileRule";
 import type { RuleRegistration } from "@/lib/storage";
 import { isEqual } from "es-toolkit";
 import { match } from "ts-pattern";
-import { useNativeResourceTypeBehaviorStorage, useProfileId2ErrorMessageRecordStorage, useProfileId2RelatedRuleIdRecordStorage } from "@/lib/storage";
+import { useProfileId2ErrorMessageRecordStorage, useProfileId2RelatedRuleIdRecordStorage } from "@/lib/storage";
 import { deriveRuleScope, RULE_SCOPES } from "../profileRule";
 import { buildAction } from "./buildAction";
 import { buildCondition } from "./buildCondition";
@@ -99,12 +99,10 @@ async function deleteRules(changes: Pick<ProfileChanges, "deleted">) {
 async function upsertRules(changes: Pick<ProfileChanges, "created" | "modified">) {
   const results: RuleUpdateResult[] = [];
   const profilesToRegister = [...changes.created, ...changes.modified];
-  const { item: nativeResourceTypeBehaviorItem } = useNativeResourceTypeBehaviorStorage();
-  const nativeResourceTypeBehavior = await nativeResourceTypeBehaviorItem.getValue();
   const registrationRecord = await profileId2RelatedRuleIdRecordItem.getValue();
 
   for (const profile of profilesToRegister) {
-    const condition = buildCondition(profile, { nativeResourceTypeBehavior });
+    const condition = buildCondition(profile);
     const ruleScope = deriveRuleScope(condition);
     // Treat creation as an upsert too. A full re-registration and a queued
     // profile-created event can otherwise register the same profile twice.

--- a/extension/src/entrypoints/popup/pages/profiles/components/ProfileActions/__TESTS__/actions.test.ts
+++ b/extension/src/entrypoints/popup/pages/profiles/components/ProfileActions/__TESTS__/actions.test.ts
@@ -1,0 +1,36 @@
+import type { Profile } from "@/lib/schema";
+import { describe, expect, it } from "vitest";
+import { createProfile } from "@/lib/profileFactory";
+import { handleProfileRuleActionTypeChanged } from "../actions";
+
+describe("handleProfileRuleActionTypeChanged", () => {
+  it("keeps only frame resource types when converting to allowAllRequests", async () => {
+    const profile = createProfile({
+      ruleActionType: "allowAllRequests",
+      filters: {
+        resourceTypes: {
+          type: "checkbox",
+          items: [{
+            id: "550e8400-e29b-41d4-a716-446655440001",
+            enabled: true,
+            value: ["main_frame", "script", "sub_frame"],
+          }],
+        },
+        excludedResourceTypes: {
+          type: "checkbox",
+          items: [{
+            id: "550e8400-e29b-41d4-a716-446655440002",
+            enabled: true,
+            value: ["image", "sub_frame"],
+          }],
+        },
+      },
+    });
+
+    await handleProfileRuleActionTypeChanged(profile);
+
+    const filters = profile.filters as Profile["filters"];
+    expect(filters.resourceTypes?.items[0]?.value).toEqual(["main_frame", "sub_frame"]);
+    expect(filters.excludedResourceTypes?.items[0]?.value).toEqual(["sub_frame"]);
+  });
+});

--- a/extension/src/entrypoints/popup/pages/profiles/components/ProfileActions/actions.ts
+++ b/extension/src/entrypoints/popup/pages/profiles/components/ProfileActions/actions.ts
@@ -6,7 +6,7 @@ import { useRouter } from "vue-router";
 import { useProfilesStore } from "@/entrypoints/popup/stores/useProfilesStore";
 import { getCurrentTabHostname } from "@/lib/currentTab";
 import { createHeaderMod, createRedirectUrl } from "@/lib/profileFactory";
-import { addProfileIds, stripProfileIds } from "@/lib/schema";
+import { addProfileIds, ALLOW_ALL_REQUESTS_RESOURCE_TYPES, stripProfileIds } from "@/lib/schema";
 
 export type ActionKey
   = | "toggle"
@@ -119,6 +119,15 @@ export async function handleProfileRuleActionTypeChanged(profile: Profile) {
       }
     })
     .exhaustive();
+
+  if (profile.ruleActionType === "allowAllRequests") {
+    for (const filterType of ["resourceTypes", "excludedResourceTypes"] as const) {
+      const filterGroup = profile.filters[filterType];
+      filterGroup?.items.forEach((item) => {
+        item.value = item.value.filter(resourceType => ALLOW_ALL_REQUESTS_RESOURCE_TYPES.includes(resourceType));
+      });
+    }
+  }
 
   if (Object.keys(profile.filters).length > 0) {
     return;

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/ResourceTypeOrRequestMethod.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/ResourceTypeOrRequestMethod.vue
@@ -86,7 +86,7 @@ const options = computed(() => {
     return conditionOptions;
   }
 
-  return conditionOptions.filter(option => ALLOW_ALL_REQUESTS_RESOURCE_TYPES.includes(option.value as ResourceTypeValue));
+  return conditionOptions.filter(option => ALLOW_ALL_REQUESTS_RESOURCE_TYPES.includes(option.value));
 });
 
 const name = computed(() => {

--- a/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/ResourceTypeOrRequestMethod.vue
+++ b/extension/src/entrypoints/popup/pages/profiles/components/SelectedProfile/conditions/ResourceTypeOrRequestMethod.vue
@@ -11,6 +11,7 @@ import MultiSelect from "#/ui/multi-select/MultiSelect.vue";
 import { useProfilesStore } from "@/entrypoints/popup/stores/useProfilesStore";
 import { addItemToGroup } from "@/lib/group";
 import { getProfileFilterGroupOpenStateId } from "@/lib/openState";
+import { ALLOW_ALL_REQUESTS_RESOURCE_TYPES } from "@/lib/schema";
 
 type FilterItem<V extends FilterValue> = GroupItem & {
   value: V[];
@@ -76,7 +77,17 @@ const optionsMap: {
   excludedRequestMethods: requestMethodsOptions,
 };
 
-const options = computed(() => optionsMap[type]);
+const options = computed(() => {
+  const conditionOptions = optionsMap[type];
+  if (
+    profilesStore.selectedProfile.ruleActionType !== "allowAllRequests"
+    || (type !== "resourceTypes" && type !== "excludedResourceTypes")
+  ) {
+    return conditionOptions;
+  }
+
+  return conditionOptions.filter(option => ALLOW_ALL_REQUESTS_RESOURCE_TYPES.includes(option.value as ResourceTypeValue));
+});
 
 const name = computed(() => {
   const nameMap = {

--- a/extension/src/entrypoints/popup/pages/settings/fields.ts
+++ b/extension/src/entrypoints/popup/pages/settings/fields.ts
@@ -84,18 +84,5 @@ export function useCreateSettings() {
         },
       ],
     },
-    {
-      fieldsetTitle: t("settings.groups.declarativeNetRequest"),
-      anchor: "declarativeNetRequest",
-      anchorIcon: "i-lucide-code-xml",
-      fields: [
-        {
-          type: "checkbox",
-          label: t("settings.fields.nativeResourceTypeBehavior"),
-          key: "nativeResourceTypeBehavior",
-          description: t("settings.descriptions.nativeResourceTypeBehavior"),
-        },
-      ],
-    },
   ] satisfies SettingGroup[]);
 }

--- a/extension/src/entrypoints/popup/stores/useSettingsStore.ts
+++ b/extension/src/entrypoints/popup/stores/useSettingsStore.ts
@@ -4,7 +4,6 @@ import { computed } from "vue";
 import {
   useHideRecentlyAddedStorage,
   useLanguageStorage,
-  useNativeResourceTypeBehaviorStorage,
   usePowerOnStorage,
   useShowCommentsInlineStorage,
 } from "@/lib/storage";
@@ -15,7 +14,6 @@ export const useSettingsStore = defineStore("settings", () => {
   });
   const storageConfigs = {
     powerOn: usePowerOnStorage(),
-    nativeResourceTypeBehavior: useNativeResourceTypeBehaviorStorage(),
     language: useLanguageStorage(),
     showCommentsInline: useShowCommentsInlineStorage(),
     hideRecentlyAdded: useHideRecentlyAddedStorage(),

--- a/extension/src/lib/__TESTS__/buildCondition.test.ts
+++ b/extension/src/lib/__TESTS__/buildCondition.test.ts
@@ -67,7 +67,7 @@ describe("buildCondition", () => {
       },
     });
 
-    const condition = buildCondition(profile, { nativeResourceTypeBehavior: false });
+    const condition = buildCondition(profile);
 
     expect(condition.resourceTypes).toEqual(["script", "stylesheet"]);
     expect(condition.excludedResourceTypes).toEqual(["font"]);
@@ -75,26 +75,5 @@ describe("buildCondition", () => {
     expect(condition.excludedRequestMethods).toEqual(["delete"]);
     expect(condition.tabIds).toEqual([42, 43, 45, 46]);
     expect(condition.excludedTabIds).toEqual([44, 47]);
-  });
-
-  it("restricts allowAllRequests resource type conditions to frames", () => {
-    const profile = createProfile({
-      ruleActionType: "allowAllRequests",
-      filters: {
-        resourceTypes: {
-          type: "checkbox",
-          items: [createFilterItem(1, ["main_frame", "script", "sub_frame"])],
-        },
-        excludedResourceTypes: {
-          type: "checkbox",
-          items: [createFilterItem(2, ["image", "sub_frame"])],
-        },
-      },
-    });
-
-    const condition = buildCondition(profile, { nativeResourceTypeBehavior: false });
-
-    expect(condition.resourceTypes).toEqual(["main_frame", "sub_frame"]);
-    expect(condition.excludedResourceTypes).toEqual(["sub_frame"]);
   });
 });

--- a/extension/src/lib/__TESTS__/buildCondition.test.ts
+++ b/extension/src/lib/__TESTS__/buildCondition.test.ts
@@ -76,4 +76,25 @@ describe("buildCondition", () => {
     expect(condition.tabIds).toEqual([42, 43, 45, 46]);
     expect(condition.excludedTabIds).toEqual([44, 47]);
   });
+
+  it("restricts allowAllRequests resource type conditions to frames", () => {
+    const profile = createProfile({
+      ruleActionType: "allowAllRequests",
+      filters: {
+        resourceTypes: {
+          type: "checkbox",
+          items: [createFilterItem(1, ["main_frame", "script", "sub_frame"])],
+        },
+        excludedResourceTypes: {
+          type: "checkbox",
+          items: [createFilterItem(2, ["image", "sub_frame"])],
+        },
+      },
+    });
+
+    const condition = buildCondition(profile, { nativeResourceTypeBehavior: false });
+
+    expect(condition.resourceTypes).toEqual(["main_frame", "sub_frame"]);
+    expect(condition.excludedResourceTypes).toEqual(["sub_frame"]);
+  });
 });

--- a/extension/src/lib/schema/base.ts
+++ b/extension/src/lib/schema/base.ts
@@ -51,6 +51,11 @@ export const RESOURCE_TYPES = [
 ] as const satisfies `${Browser.declarativeNetRequest.ResourceType}`[];
 export const resourceTypeSchema = z.enum(RESOURCE_TYPES);
 
+export const ALLOW_ALL_REQUESTS_RESOURCE_TYPES = [
+  "main_frame",
+  "sub_frame",
+] as const satisfies (typeof RESOURCE_TYPES)[number][];
+
 export const REQUEST_METHODS = [
   "connect",
   "delete",

--- a/extension/src/lib/schema/index.ts
+++ b/extension/src/lib/schema/index.ts
@@ -1,4 +1,5 @@
 export {
+  ALLOW_ALL_REQUESTS_RESOURCE_TYPES,
   DOMAIN_TYPES,
   profileGroupSchema,
   REQUEST_METHODS,

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -150,10 +150,6 @@ export function usePowerOnStorage() {
   return useExtensionStorageWrapper<boolean>("local:powerOn", true);
 }
 
-export function useNativeResourceTypeBehaviorStorage() {
-  return useExtensionStorageWrapper<boolean>("local:nativeResourceTypeBehavior", false);
-}
-
 export function useLanguageStorage() {
   const browserLanguage = browser.i18n.getUILanguage().replace("_", "-");
   const initialLanguage = SUPPORT_LOCALES.includes(browserLanguage) ? browserLanguage as SupportLocale : "en";

--- a/extension/src/locales/en.json
+++ b/extension/src/locales/en.json
@@ -454,20 +454,17 @@
   "settings": {
     "descriptions": {
       "hideRecentlyAdded": "Hide shortcuts for recently added request and response header names.",
-      "nativeResourceTypeBehavior": "Resource type defaults to 'all', but enabling this option will not set it to 'all', and rules without a resource type condition will match only a narrower range of requests.",
       "showCommentsInline": "Show each field's comments next to its other actions instead of in the More Actions menu."
     },
     "fieldLabel": "{label}:",
     "fields": {
       "hideRecentlyAdded": "Hide recently added headers",
       "language": "Language",
-      "nativeResourceTypeBehavior": "Use native DNR resource type behavior",
       "showCommentsInline": "Show field comments inline",
       "theme": "Theme"
     },
     "groups": {
       "appearance": "Appearance",
-      "declarativeNetRequest": "Declarative Net Request",
       "profiles": "Profiles",
       "troubleshooting": "Troubleshooting"
     },

--- a/extension/src/locales/zh-CN.json
+++ b/extension/src/locales/zh-CN.json
@@ -454,20 +454,17 @@
   "settings": {
     "descriptions": {
       "hideRecentlyAdded": "隐藏最近添加的请求头和响应头名称快捷入口。",
-      "nativeResourceTypeBehavior": "资源类型默认是 'all'，但启用此选项后不会设置为 'all'，没有资源类型条件的规则只会匹配更窄范围的请求。",
       "showCommentsInline": "将每个字段的备注显示在其他操作旁，而不是放在“更多选项”菜单中。"
     },
     "fieldLabel": "{label}：",
     "fields": {
       "hideRecentlyAdded": "隐藏最近添加的标头",
       "language": "语言",
-      "nativeResourceTypeBehavior": "使用原生 DNR 资源类型行为",
       "showCommentsInline": "在字段外侧显示备注",
       "theme": "主题"
     },
     "groups": {
       "appearance": "外观",
-      "declarativeNetRequest": "声明式网络请求",
       "profiles": "配置",
       "troubleshooting": "故障排查"
     },


### PR DESCRIPTION
## Summary

- Restrict `allowAllRequests` resource-type selectors to `main_frame` and `sub_frame`.
- Remove unsupported resource types when a profile is converted to `allowAllRequests`.
- Defensively filter persisted or imported unsupported values before DNR rule generation.

## Root cause

The default DNR condition handled `allowAllRequests`, but the UI and action-type conversion still accepted resource types unsupported by that action.

## Validation

- `pnpm run lint:fix`
- `pnpm --filter=extension exec vitest run src/lib/__TESTS__/buildCondition.test.ts src/entrypoints/popup/pages/profiles/components/ProfileActions/__TESTS__/actions.test.ts`
- `pnpm --filter=extension run typecheck` *(blocked by an existing type error in `src/entrypoints/popup/pages/export/[[id]].vue:120`)*
